### PR TITLE
Added method to allow custom RPC commands

### DIFF
--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -79,6 +79,6 @@ func MethodGetConfig(source string) RawMethod {
 	return RawMethod(fmt.Sprintf("<get-config><source><%s/></source></get-config>", source))
 }
 
-func MethodRPC(command string) RawMethod {
+func RawRPC(command string) RawMethod {
 	return RawMethod(fmt.Sprintf("%s", command))
 }

--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
+	"strings"
 )
 
 type RPCMessage struct {
@@ -54,7 +55,7 @@ type RPCError struct {
 }
 
 func (re *RPCError) Error() string {
-	return fmt.Sprintf("netconf rpc [%s] '%s'", re.Severity, re.Message)
+	return fmt.Sprintf("netconf rpc [%s]: %s", re.Severity, strings.Trim(re.Message, "[\r\n]"))
 }
 
 type RPCMethod interface {

--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -78,3 +78,7 @@ func MethodUnlock(target string) RawMethod {
 func MethodGetConfig(source string) RawMethod {
 	return RawMethod(fmt.Sprintf("<get-config><source><%s/></source></get-config>", source))
 }
+
+func MethodRPC(command string) RawMethod {
+	return RawMethod(fmt.Sprintf("%s", command))
+}

--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -79,6 +79,7 @@ func MethodGetConfig(source string) RawMethod {
 	return RawMethod(fmt.Sprintf("<get-config><source><%s/></source></get-config>", source))
 }
 
+// RawRPC allows any RPC command to be run on the target.
 func RawRPC(command string) RawMethod {
 	return RawMethod(fmt.Sprintf("%s", command))
 }


### PR DESCRIPTION
This will allow any RPC command (`<get-software-information/>`, `<get-chassis-inventory/>`, etc.) to be called similar to how the built in functions work.
