### PR TITLE
send XML declaration to enhance compatibility with some devices

### DIFF
--- a/netconf/session.go
+++ b/netconf/session.go
@@ -26,6 +26,9 @@ func (s *Session) Exec(methods ...RPCMethod) (*RPCReply, error) {
 		return nil, err
 	}
 
+	header := []byte(xml.Header)
+	request = append(header, request...)
+
 	log.Debugf("REQUEST: %s\n", request)
 
 	err = s.Transport.Send(request)

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -59,6 +59,8 @@ func (t *transportBasicIO) SendHello(hello *HelloMessage) error {
 		return err
 	}
 
+	header := []byte(xml.Header)
+	val = append(header, val...)
 	err = t.Send(val)
 	return err
 }


### PR DESCRIPTION
This PR sends the standard XML declaration (<?xml version="1.0" encoding="UTF-8"?>) as part of Hello and Exec requests.
Sending a XML declaration is a MAY in [RFC6241 section 3](https://tools.ietf.org/html/rfc6241#section-3) but some devices aren't able to parse the request without it.