### PR TITLE
Add Go 1.7 to travis.yml and drop release in favor of tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ go:
   - 1.4
   - 1.5
   - 1.6
-  - release
+  - 1.7
   - tip
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - go: tip
 
 install: (cd netconf; go get -d -v ./... && go build -v ./...)
 before_script:


### PR DESCRIPTION
`- release` isn't valid and is causing Travis-CI tests to fail.  This PR removes the `- release` tag in favor of `- tip` and also add Go 1.7 testing