### PR TITLE
Namespace

### DIFF
--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -29,9 +29,11 @@ func (m *RPCMessage) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 	data := struct {
 		MessageID string `xml:"message-id,attr"`
+		Xmlns     string `xml:"xmlns,attr"`
 		Methods   []byte `xml:",innerxml"`
 	}{
 		m.MessageID,
+		"urn:ietf:params:xml:ns:netconf:base:1.0",
 		buf.Bytes(),
 	}
 

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -20,7 +20,7 @@ var DefaultCapabilities = []string{
 
 // HelloMessage is used when bringing up a NetConf session
 type HelloMessage struct {
-	XMLName      xml.Name `xml:"hello"`
+	XMLName      xml.Name `xml:"urn:ietf:params:xml:ns:netconf:base:1.0 hello"`
 	Capabilities []string `xml:"capabilities>capability"`
 	SessionID    int      `xml:"session-id,omitempty"`
 }

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -15,7 +15,7 @@ const (
 
 // DefaultCapabilities sets the default capabilities of the client library
 var DefaultCapabilities = []string{
-	"urn:ietf:params:xml:ns:netconf:base:1.0",
+	"urn:ietf:params:netconf:base:1.0",
 }
 
 // HelloMessage is used when bringing up a NetConf session


### PR DESCRIPTION
Hi,

I had some trouble with connecting go-netconf to the [Netopeer2](https://github.com/CESNET/Netopeer2) server.

The following commits where needed to enable the communication to the Netopeer2 server, the changes are hard coded and they are:

1) add namespace to hello XML element.
2) add namespace to rpc XML element.
Netopeer2 requires a namespace for the top XML element.

3) change the namespace of the default capability.
8.1.  Capabilities Exchange
   Capabilities are advertised in messages sent by each peer during
   session establishment.  When the NETCONF session is opened, each peer
   (both client and server) MUST send a <hello> element containing a
   list of that peer's capabilities.  Each peer MUST send at least the
   base NETCONF capability, "urn:ietf:params:netconf:base:1.0".

I tried to make a more general commit but I need input from you also I am not sure will this break something on someone else's setup.

Do you have any idea how to generalize inserting namespace's to the top XML element?

