### PR TITLE
FIXED: 'must specify HostKeyCallback' 

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -152,8 +152,9 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 	return NewSession(t), nil
 }
 
-// SSHConfigPassword is a convience function that takes a username and password
+// SSHConfigPassword is a convenience function that takes a username and password
 // and returns a new ssh.ClientConfig setup to pass that username and password.
+// Convenience means that HostKey checks are disabled so it's probably less secure
 func SSHConfigPassword(user string, pass string) *ssh.ClientConfig {
 	return &ssh.ClientConfig{
 		User: user,
@@ -164,7 +165,7 @@ func SSHConfigPassword(user string, pass string) *ssh.ClientConfig {
 	}
 }
 
-// SSHConfigPubKeyFile is a convience function that takes a username, private key
+// SSHConfigPubKeyFile is a convenience function that takes a username, private key
 // and passphrase and returns a new ssh.ClientConfig setup to pass credentials
 // to DialSSH
 func SSHConfigPubKeyFile(user string, file string, passphrase string) (*ssh.ClientConfig, error) {

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -160,6 +160,7 @@ func SSHConfigPassword(user string, pass string) *ssh.ClientConfig {
 		Auth: []ssh.AuthMethod{
 			ssh.Password(pass),
 		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 }
 


### PR DESCRIPTION
Hi,

This small change should fix the "ssh: must specify HostKeyCallback" issue described in https://github.com/golang/go/issues/19767 and https://github.com/Juniper/go-netconf/issues/27