### PR TITLE
Pad the written data in case the message separator would otherwise fa…

### DIFF
--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -44,6 +44,10 @@ type transportBasicIO struct {
 // nessisary framining messages.
 func (t *transportBasicIO) Send(data []byte) error {
 	t.Write(data)
+	// Pad to make sure the msgSeparator isn't sent across a 4096-byte boundary
+	if (len(data)+len(msgSeperator))%4096 < 6 {
+		t.Write([]byte("      "))
+	}
 	t.Write([]byte(msgSeperator))
 	t.Write([]byte("\n"))
 	return nil // TODO: Implement error handling!


### PR DESCRIPTION
…ll on a 4096-byte boundary

In case a large payload is sent to the Juniper devices via XML-RPC it freaks out if the message separator ("]]>]]>") is split across a 4096-byte boundary. This fix makes sure the separator is never split.