### PR TITLE
Use uppercase NETCONF in all comments

### DIFF
--- a/netconf/rpc.go
+++ b/netconf/rpc.go
@@ -20,7 +20,7 @@ func NewRPCMessage(methods []RPCMethod) *RPCMessage {
 	}
 }
 
-// MarshalXML marshals the NetConf XML data
+// MarshalXML marshals the NETCONF XML data
 func (m *RPCMessage) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	var buf bytes.Buffer
 	for _, method := range m.Methods {
@@ -77,17 +77,17 @@ func (r RawMethod) MarshalMethod() string {
 	return string(r)
 }
 
-// MethodLock files a Netconf lock target request with the remote host
+// MethodLock files a NETCONF lock target request with the remote host
 func MethodLock(target string) RawMethod {
 	return RawMethod(fmt.Sprintf("<lock><target><%s/></target></lock>", target))
 }
 
-// MethodUnlock files a Netconf unlock target request with the remote host
+// MethodUnlock files a NETCONF unlock target request with the remote host
 func MethodUnlock(target string) RawMethod {
 	return RawMethod(fmt.Sprintf("<unlock><target><%s/></target></unlock>", target))
 }
 
-// MethodGetConfig files a Netconf get-config source request with the remote host
+// MethodGetConfig files a NETCONF get-config source request with the remote host
 func MethodGetConfig(source string) RawMethod {
 	return RawMethod(fmt.Sprintf("<get-config><source><%s/></source></get-config>", source))
 }

--- a/netconf/session.go
+++ b/netconf/session.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 )
 
-// Session defines the necessary components for a Netconf session
+// Session defines the necessary components for a NETCONF session
 type Session struct {
 	Transport          Transport
 	SessionID          int
@@ -62,7 +62,7 @@ func (s *Session) Exec(methods ...RPCMethod) (*RPCReply, error) {
 	return reply, nil
 }
 
-// NewSession creates a new NetConf session using the provided transport layer.
+// NewSession creates a new NETCONF session using the provided transport layer.
 func NewSession(t Transport) *Session {
 	s := new(Session)
 	s.Transport = t

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	// msgSeperator is used to separate sent messages via NetConf
+	// msgSeperator is used to separate sent messages via NETCONF
 	msgSeperator = "]]>]]>"
 )
 
@@ -18,14 +18,14 @@ var DefaultCapabilities = []string{
 	"urn:ietf:params:xml:ns:netconf:base:1.0",
 }
 
-// HelloMessage is used when bringing up a NetConf session
+// HelloMessage is used when bringing up a NETCONF session
 type HelloMessage struct {
 	XMLName      xml.Name `xml:"hello"`
 	Capabilities []string `xml:"capabilities>capability"`
 	SessionID    int      `xml:"session-id,omitempty"`
 }
 
-// Transport interface defines what characterisitics make up a NetConf transport
+// Transport interface defines what characterisitics make up a NETCONF transport
 // layer object.
 type Transport interface {
 	Send([]byte) error
@@ -40,7 +40,7 @@ type transportBasicIO struct {
 	chunkedFraming bool
 }
 
-// Sends a well formated netconf rpc message as a slice of bytes adding on the
+// Sends a well formated NETCONF rpc message as a slice of bytes adding on the
 // nessisary framining messages.
 func (t *transportBasicIO) Send(data []byte) error {
 	t.Write(data)

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	// sshDefaultPort is the default SSH port used when communicating with NetConf
+	// sshDefaultPort is the default SSH port used when communicating with
+	// NETCONF
 	sshDefaultPort = 830
-	// sshNetconfSubsystem sets the SSH subsystem to NetConf
+	// sshNetconfSubsystem sets the SSH subsystem to NETCONF
 	sshNetconfSubsystem = "netconf"
 )
 

--- a/netconf/transport_telnet.go
+++ b/netconf/transport_telnet.go
@@ -15,14 +15,14 @@ const (
 	telnetTimeout = 10 * time.Second
 )
 
-// VendorIOProc is the interface used when establishing a telnet Netconf session
+// VendorIOProc is the interface used when establishing a telnet NETCONF session
 type VendorIOProc interface {
 	Login(*TransportTelnet, string, string) error
 	StartNetconf(*TransportTelnet) error
 }
 
 // TransportTelnet is used to define what makes up a Telnet Transport layer for
-// NetConf
+// NETCONF
 type TransportTelnet struct {
 	transportBasicIO
 	telnetConn *telnet.Conn


### PR DESCRIPTION
As per the RFC the protocol is called NETCONF, not netconf, Netconf, or
NetConf.