### PR TITLE
add optional XML header parameter for HelloMessage

### DIFF
--- a/netconf/session.go
+++ b/netconf/session.go
@@ -58,7 +58,7 @@ func NewSession(t Transport) *Session {
 	s.ServerCapabilities = serverHello.Capabilities
 
 	// Send our hello using default capabilities.
-	t.SendHello(&HelloMessage{Capabilities: DefaultCapabilities})
+	t.SendHello(&HelloMessage{Capabilities: DefaultCapabilities}, true)
 
 	return s
 }

--- a/netconf/transport.go
+++ b/netconf/transport.go
@@ -32,7 +32,7 @@ type Transport interface {
 	Receive() ([]byte, error)
 	Close() error
 	ReceiveHello() (*HelloMessage, error)
-	SendHello(*HelloMessage) error
+	SendHello(*HelloMessage, bool) error
 }
 
 type transportBasicIO struct {
@@ -57,13 +57,20 @@ func (t *transportBasicIO) Receive() ([]byte, error) {
 	return t.WaitForBytes([]byte(msgSeperator))
 }
 
-func (t *transportBasicIO) SendHello(hello *HelloMessage) error {
+func (t *transportBasicIO) SendHello(hello *HelloMessage, addXMLheader bool) error {
 	val, err := xml.Marshal(hello)
 	if err != nil {
 		return err
 	}
 
-	header := []byte(xml.Header)
+	var header []byte
+
+	if addXMLheader {
+		header = []byte(xml.Header)
+	} else {
+		header = []byte("")
+	}
+
 	val = append(header, val...)
 	err = t.Send(val)
 	return err

--- a/netconf/transport_test.go
+++ b/netconf/transport_test.go
@@ -110,7 +110,7 @@ func TestSendHello(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			trans, out := newTransportTest("")
-			trans.SendHello(tc.input)
+			trans.SendHello(tc.input, true)
 			rawHello := out.String()
 
 			if rawHello != tc.expected {


### PR DESCRIPTION
This is needed for some HP switches for example HP 5940.

This box does not expect XML header in hello message.

New Boolean optionally disables this header.