### PR TITLE
Transport JunOS

### DIFF
--- a/netconf/transport_junos.go
+++ b/netconf/transport_junos.go
@@ -1,3 +1,11 @@
+// Copyright (c) 2018, Juniper Networks, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Transport JunOS provides the ability to communicate with JunOS via local shell
+NETCONF interface (xml-mode netconf need-trailer).
+*/
 package netconf
 
 import (
@@ -11,24 +19,16 @@ type TransportJunOS struct {
 	cmd *exec.Cmd
 }
 
-// Close closes an existing session.
+// Close closes an existing local NETCONF session.
 func (t *TransportJunOS) Close() error {
-	return nil
-}
-
-// Open creates a new session.
-func (t *TransportJunOS) Open() error {
-	var err error
-
-	err = t.setup()
-	if err != nil {
-		return err
+	if t.cmd != nil {
+		t.ReadWriteCloser.Close()
 	}
 	return nil
 }
 
-// setup executes the local shell command.
-func (t *TransportJunOS) setup() error {
+// Open creates a new local NETCONF session.
+func (t *TransportJunOS) Open() error {
 	var err error
 
 	t.cmd = exec.Command("xml-mode", "netconf", "need-trailer")

--- a/netconf/transport_junos.go
+++ b/netconf/transport_junos.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 /*
-Transport JunOS provides the ability to communicate with JunOS via local shell
+Transport Junos provides the ability to communicate with Junos via local shell
 NETCONF interface (xml-mode netconf need-trailer).
 */
 package netconf
@@ -12,15 +12,15 @@ import (
 	"os/exec"
 )
 
-// TransportJunOS maintains the information necessary to communicate with JunOS
+// TransportJunos maintains the information necessary to communicate with Junos
 // via local shell.
-type TransportJunOS struct {
+type TransportJunos struct {
 	transportBasicIO
 	cmd *exec.Cmd
 }
 
 // Close closes an existing local NETCONF session.
-func (t *TransportJunOS) Close() error {
+func (t *TransportJunos) Close() error {
 	if t.cmd != nil {
 		t.ReadWriteCloser.Close()
 	}
@@ -28,7 +28,7 @@ func (t *TransportJunOS) Close() error {
 }
 
 // Open creates a new local NETCONF session.
-func (t *TransportJunOS) Open() error {
+func (t *TransportJunos) Open() error {
 	var err error
 
 	t.cmd = exec.Command("xml-mode", "netconf", "need-trailer")
@@ -47,9 +47,9 @@ func (t *TransportJunOS) Open() error {
 	return t.cmd.Start()
 }
 
-// JunOS creates a new NETCONF session using shell transport.
-func JunOS() (*Session, error) {
-	var t TransportJunOS
+// Junos creates a new NETCONF session using shell transport.
+func Junos() (*Session, error) {
+	var t TransportJunos
 	err := t.Open()
 	if err != nil {
 		return nil, err

--- a/netconf/transport_junos.go
+++ b/netconf/transport_junos.go
@@ -1,0 +1,58 @@
+package netconf
+
+import (
+	"os/exec"
+)
+
+// TransportJunOS maintains the information necessary to communicate with JunOS
+// via local shell.
+type TransportJunOS struct {
+	transportBasicIO
+	cmd *exec.Cmd
+}
+
+// Close closes an existing session.
+func (t *TransportJunOS) Close() error {
+	return nil
+}
+
+// Open creates a new session.
+func (t *TransportJunOS) Open() error {
+	var err error
+
+	err = t.setup()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// setup executes the local shell command.
+func (t *TransportJunOS) setup() error {
+	var err error
+
+	t.cmd = exec.Command("xml-mode", "netconf", "need-trailer")
+
+	writer, err := t.cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	reader, err := t.cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	t.ReadWriteCloser = NewReadWriteCloser(reader, writer)
+	return t.cmd.Start()
+}
+
+// JunOS creates a new NETCONF session using shell transport.
+func JunOS() (*Session, error) {
+	var t TransportJunOS
+	err := t.Open()
+	if err != nil {
+		return nil, err
+	}
+	return NewSession(&t), nil
+}

--- a/netconf/transport_junos.go
+++ b/netconf/transport_junos.go
@@ -48,7 +48,7 @@ func (t *TransportJunos) Open() error {
 }
 
 // Junos creates a new NETCONF session using shell transport.
-func Junos() (*Session, error) {
+func DialJunos() (*Session, error) {
 	var t TransportJunos
 	err := t.Open()
 	if err != nil {

--- a/netconf/transport_junos.go
+++ b/netconf/transport_junos.go
@@ -33,17 +33,17 @@ func (t *TransportJunos) Open() error {
 
 	t.cmd = exec.Command("xml-mode", "netconf", "need-trailer")
 
-	writer, err := t.cmd.StdinPipe()
+	w, err := t.cmd.StdinPipe()
 	if err != nil {
 		return err
 	}
 
-	reader, err := t.cmd.StdoutPipe()
+	r, err := t.cmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
 
-	t.ReadWriteCloser = NewReadWriteCloser(reader, writer)
+	t.ReadWriteCloser = NewReadWriteCloser(r, w)
 	return t.cmd.Start()
 }
 


### PR DESCRIPTION
This new transport uses the local command `xml-mode netconf need-trailer` to open a NETCONF session, which is required for GO running on JunOS (on-box cross compiled via JET SDK). 

```go
        s, err := netconf.JunOS()

        reply, err := s.Exec(netconf.RawMethod("<get-system-information/>"))
```
