### PR TITLE
enable rpc message logging for debug purposes issue #68

### DIFF
--- a/examples/ssh1/ssh1.go
+++ b/examples/ssh1/ssh1.go
@@ -9,6 +9,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/Juniper/go-netconf/netconf"
 	"golang.org/x/crypto/ssh"
@@ -28,6 +29,9 @@ func main() {
 	}
 
 	defer s.Close()
+
+	// enable RPC logging
+	netconf.Logger.SetOutput(os.Stderr)
 
 	fmt.Println(s.ServerCapabilities)
 	fmt.Println(s.SessionID)

--- a/netconf/log.go
+++ b/netconf/log.go
@@ -1,0 +1,28 @@
+// Go NETCONF Client
+//
+// Copyright (c) 2013-2018, Juniper Networks, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netconf
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func init() {
+	// Discard is an io.Writer on which all Write calls succeed without doing anything.
+	Logger.SetOutput(ioutil.Discard)
+}
+
+// NopLogger is a wrapper for the standard logger
+type NopLogger struct {
+	*log.Logger
+}
+
+// Logger provides request and response payload logging for the Netconf Exec
+var Logger = &NopLogger{
+	log.New(os.Stderr, "", log.LstdFlags),
+}

--- a/netconf/log_test.go
+++ b/netconf/log_test.go
@@ -1,0 +1,34 @@
+// Go NETCONF Client
+//
+// Copyright (c) 2013-2018, Juniper Networks, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package netconf
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func BenchmarkLog(b *testing.B) {
+	log.SetFlags(log.LstdFlags)
+	file, err := ioutil.TempFile("", "benchmark-log")
+	if err != nil {
+		log.SetOutput(os.Stderr)
+	} else {
+		log.SetOutput(file)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		log.Printf("Benchmark %d", i)
+	}
+}
+
+func BenchmarkNopLogger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Logger.Println("Benchmark %d", i)
+	}
+}

--- a/netconf/session.go
+++ b/netconf/session.go
@@ -44,6 +44,9 @@ func (s *Session) Exec(methods ...RPCMethod) (*RPCReply, error) {
 		return nil, err
 	}
 
+	// write the request to a no op logger, which can be overriden by the library user
+	Logger.Println(string(request))
+
 	rawXML, err := s.Transport.Receive()
 	if err != nil {
 		return nil, err
@@ -53,6 +56,9 @@ func (s *Session) Exec(methods ...RPCMethod) (*RPCReply, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// write the response to a no op logger, which can be overriden by the library user
+	Logger.Println(reply.RawReply)
 
 	return reply, nil
 }


### PR DESCRIPTION
Can be enabled as follows by the user of go-netconf

```
netconf.Logger.SetOutput(os.Stderr)
```

Trivial implementation, no third party library, Benchmarks provided to access the impact.  