### PR TITLE
fix hostkeycallback for other authentication methods

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -197,6 +197,7 @@ func SSHConfigPubKeyFile(user string, file string, passphrase string) (*ssh.Clie
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(key),
 		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}, nil
 
 }
@@ -214,6 +215,7 @@ func SSHConfigPubKeyAgent(user string) (*ssh.ClientConfig, error) {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeysCallback(agent.NewClient(c).Signers),
 		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}, nil
 }
 


### PR DESCRIPTION
Using the SSHConfig* convenience functions for SSH private key and SSH agent authentication results in a `ssh: must specify HostKeyCallback` error.

Added `ssh.InsecureIgnoreHostKey` to the ssh.ClientConfig structs so that they are inline with the SSHConfigPassword function (which was fixed in commit 418667039b1b346153765ff4b442e1bf42b2a9d5)
