### PR TITLE
Allow pass through of address to ssh.NewClientConn()

### DIFF
--- a/examples/ssh3/ssh3.go
+++ b/examples/ssh3/ssh3.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/user"
+
+	"github.com/Juniper/go-netconf/netconf"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func sshAgent() ssh.AuthMethod {
+	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
+		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
+	}
+	return nil
+}
+
+func getSessionID(addr string, sshConfig *ssh.ClientConfig) (int, error) {
+	bastionClient, err := ssh.Dial("tcp", "bastion-host.example.net:22", sshConfig)
+	if err != nil {
+		return 0, fmt.Errorf("error dialing bastion host: %v", err)
+	}
+	defer bastionClient.Close()
+
+	tunConn, err := bastionClient.Dial("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer tunConn.Close()
+
+	sess, err := netconf.NewSSHSession(tunConn, addr, sshConfig)
+	if err != nil {
+		return 0, err
+	}
+	defer sess.Close()
+
+	id := sess.SessionID
+	return id, nil
+}
+
+func main() {
+	/*
+		Example of connecting via an SSH bastion host using SSH agent authentication
+		and known_hosts public key checking.
+	*/
+	u, err := user.Current()
+	if err != nil {
+		log.Fatalf("error retrieving current user: %v\n", err)
+	}
+
+	kHosts, err := knownhosts.New(u.HomeDir + "/.ssh/known_hosts")
+	if err != nil {
+		log.Fatalf("error reading known hosts file: %v\n", err)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            "myuser",
+		Auth:            []ssh.AuthMethod{sshAgent()},
+		HostKeyCallback: kHosts,
+	}
+
+	id, err := getSessionID("netconf-device.corp.local:22", sshConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(id)
+}

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -127,7 +127,7 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 	}
 
 	conn := &deadlineConn{Conn: bareConn, timeout: timeout}
-	t, err := connToTransport(conn, bareConn.RemoteAddr().String(), config)
+	t, err := connToTransport(conn, "", config)
 	if err != nil {
 		return nil, err
 	}
@@ -213,6 +213,10 @@ func SSHConfigPubKeyAgent(user string) (*ssh.ClientConfig, error) {
 }
 
 func connToTransport(conn net.Conn, addr string, config *ssh.ClientConfig) (*TransportSSH, error) {
+	if addr == "" {
+		addr = conn.RemoteAddr().String()
+	}
+
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
 		return nil, err

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -101,8 +101,8 @@ func (t *TransportSSH) setupSession() error {
 }
 
 // NewSSHSession creates a new NETCONF session using an existing net.Conn.
-func NewSSHSession(conn net.Conn, config *ssh.ClientConfig) (*Session, error) {
-	t, err := connToTransport(conn, config)
+func NewSSHSession(conn net.Conn, addr string, config *ssh.ClientConfig) (*Session, error) {
+	t, err := connToTransport(conn, addr, config)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 	}
 
 	conn := &deadlineConn{Conn: bareConn, timeout: timeout}
-	t, err := connToTransport(conn, config)
+	t, err := connToTransport(conn, bareConn.RemoteAddr().String(), config)
 	if err != nil {
 		return nil, err
 	}
@@ -217,8 +217,8 @@ func SSHConfigPubKeyAgent(user string) (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-func connToTransport(conn net.Conn, config *ssh.ClientConfig) (*TransportSSH, error) {
-	c, chans, reqs, err := ssh.NewClientConn(conn, conn.RemoteAddr().String(), config)
+func connToTransport(conn net.Conn, addr string, config *ssh.ClientConfig) (*TransportSSH, error) {
+	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I was having an issue creating a netconf session via an SSH jump host when using a known_hosts HostsKeyCallback. The Go SSH client intentionally sets `net.Conn.RemoteAddr` to zero when dialing a session from an existing SSH client. I believe this is why the address is an argument to the `ssh.NewClientConn` function.

`netconf.NewSSHSession` as currently implemented derives the address used for the handshake directly from the connection and does not allow it to be set manually.

Added a fix and an example but this would be a breaking change to any programs calling `netconf.NewSSHSession()`. Not sure if this is an issue with current "pre-alpha" status or if this would need to be put on hold for a major release change.

Any suggested workarounds welcome ofcourse. Took a look at setting up the transport myself but currently requires access to private attributes and methods.