### PR TITLE
added close to ssh connection if the subsystem connection fails

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -112,6 +112,7 @@ func DialSSH(target string, config *ssh.ClientConfig) (*Session, error) {
 	var t TransportSSH
 	err := t.Dial(target, config)
 	if err != nil {
+		t.Close()
 		return nil, err
 	}
 	return NewSession(&t), nil
@@ -129,6 +130,7 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 	conn := &deadlineConn{Conn: bareConn, timeout: timeout}
 	t, err := connToTransport(conn, config)
 	if err != nil {
+		t.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #86 closing the ssh connection if the subsystem connection fails, in this case the connection through netconf.