### PR TITLE
Close ssh socket even if we get an error

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -41,6 +41,9 @@ func (t *TransportSSH) Close() error {
 	// Close the SSH Session if we have one
 	if t.sshSession != nil {
 		if err := t.sshSession.Close(); err != nil {
+			// If we receive an error when trying to close the session, then
+			// lets try to close the socket, otherwise it will be left open
+			t.sshClient.Close()
 			return err
 		}
 	}


### PR DESCRIPTION
Currently if you get an error when running `t.sshSession.Close()` the
socket will be left open, and there is no way to close it. If this
happens enough times it will cause the device to stop accepting any ssh
connection until the program that has all the open connections is
closed.

Therefore I have updated to close the socket even if we see an error
when running `t.sshSession.Close()`. This way the socket isn't left in
an `ESTABLISHED` state.