### PR TITLE
fixed #89 delete xml.Header,When send rpc message

### DIFF
--- a/netconf/session.go
+++ b/netconf/session.go
@@ -36,9 +36,6 @@ func (s *Session) Exec(methods ...RPCMethod) (*RPCReply, error) {
 		return nil, err
 	}
 
-	header := []byte(xml.Header)
-	request = append(header, request...)
-
 	err = s.Transport.Send(request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I have the same question.
I modify the session.go file's code like this, is ok. But I don't know why，maybe，it‘s the h3c's problem.
I remove the xml header info, like this:

func (s *Session) Exec(methods ...RPCMethod) (*RPCReply, error) {
	rpc := NewRPCMessage(methods)

	request, err := xml.Marshal(rpc)
	if err != nil {
		return nil, err
	}
	//header := []byte(xml.Header)
	//request = append(header, request...)
	log.Debugf("REQUEST: %s\n", request)
I have no devices to test other product devices, so just the h3c device is ok.