### PR TITLE
Close transport junos cleanly

### DIFF
--- a/netconf/transport_junos.go
+++ b/netconf/transport_junos.go
@@ -18,6 +18,7 @@ type TransportJunos struct {
 // Close closes an existing local NETCONF session.
 func (t *TransportJunos) Close() error {
 	if t.cmd != nil {
+		t.cmd.Wait()
 		t.ReadWriteCloser.Close()
 	}
 	return nil


### PR DESCRIPTION
When using the `DialJunos` method a defunct process is left behind on
the router after the session is supposedly closed.

I have added a `t.cmd.Wait()` to close the process - https://golang.org/pkg/os/exec/#Cmd.Wait