### PR TITLE
transport_ssh: Check t is not nil before closing

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -136,7 +136,9 @@ func DialSSHTimeout(target string, config *ssh.ClientConfig, timeout time.Durati
 	conn := &deadlineConn{Conn: bareConn, timeout: timeout}
 	t, err := connToTransport(conn, config)
 	if err != nil {
-		t.Close()
+		if t != nil {
+			t.Close()
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
When connecting to a device where the user doesn't exist we get the
following:

```
goroutine 1 [running]:
github.com/Juniper/go-netconf/netconf.(*TransportSSH).Close(0x0, 0xc000108000, 0xc00009b040)
	/home/luke/work/src/github.com/Juniper/go-netconf/netconf/transport_ssh.go:42 +0x26
github.com/Juniper/go-netconf/netconf.DialSSHTimeout(0x62a7cb, 0x12, 0xc00009b040, 0x2540be400, 0x6325c1, 0x2f, 0xc00009b040)
	/home/luke/work/src/github.com/Juniper/go-netconf/netconf/transport_ssh.go:139 +0x110
main.main()
	/tmp/main.go:19 +0xc3
exit status 2
```

This is due to the connection being close without being established.

I have updated so we now get the following:

```
ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```