### PR TITLE
add NewSSHSessionForExternalClient for managing ssh client externally

### DIFF
--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -51,7 +51,7 @@ func (t *TransportSSH) Close() error {
 		if err := t.sshSession.Close(); err != nil {
 			// If we receive an error when trying to close the session, then
 			// lets try to close the socket, otherwise it will be left open
-			if !t.externClient {
+			if !t.managedSession {
 				t.sshClient.Close()
 			}
 			return err
@@ -59,7 +59,7 @@ func (t *TransportSSH) Close() error {
 	}
 
 	// Close the socket
-	if !t.externClient && t.sshClient != nil {
+	if !t.managedSession && t.sshClient != nil {
 		return t.sshClient.Close()
 	}
 	return fmt.Errorf("No connection to close")
@@ -262,8 +262,8 @@ func connToTransport(conn net.Conn, config *ssh.ClientConfig) (*TransportSSH, er
 
 func clientToTransport(client *ssh.Client) (*TransportSSH, error) {
 	t := &TransportSSH{
-		sshClient:    client,
-		externClient: true,
+		sshClient:      client,
+		managedSession: true,
 	}
 
 	err := t.setupSession()

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -122,9 +122,9 @@ func NewSSHSession(conn net.Conn, config *ssh.ClientConfig) (*Session, error) {
 	return NewSession(t), nil
 }
 
-// NewSSHSessionForExternalClient creates a new NETCONF session using an existing ssh.Client
+// NewSSHClientSession creates a new NETCONF session using an existing ssh.Client
 // initiated and managed externally.
-func NewSSHSessionForExternalClient(client *ssh.Client) (*Session, error) {
+func NewSSHClientSession(client *ssh.Client) (*Session, error) {
 	t, err := clientToTransport(client)
 	if err != nil {
 		return nil, err

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -125,7 +125,12 @@ func NewSSHSession(conn net.Conn, config *ssh.ClientConfig) (*Session, error) {
 // NewSSHClientSession creates a new NETCONF session using an existing ssh.Client
 // initiated and managed externally.
 func NewSSHClientSession(client *ssh.Client) (*Session, error) {
-	t, err := clientToTransport(client)
+	t := &TransportSSH{
+		sshClient:      client,
+		managedSession: true,
+	}
+
+	err := t.setupSession()
 	if err != nil {
 		return nil, err
 	}
@@ -253,20 +258,6 @@ func connToTransport(conn net.Conn, config *ssh.ClientConfig) (*TransportSSH, er
 	t.sshClient = ssh.NewClient(c, chans, reqs)
 
 	err = t.setupSession()
-	if err != nil {
-		return nil, err
-	}
-
-	return t, nil
-}
-
-func clientToTransport(client *ssh.Client) (*TransportSSH, error) {
-	t := &TransportSSH{
-		sshClient:      client,
-		managedSession: true,
-	}
-
-	err := t.setupSession()
 	if err != nil {
 		return nil, err
 	}

--- a/netconf/transport_ssh.go
+++ b/netconf/transport_ssh.go
@@ -36,7 +36,7 @@ type TransportSSH struct {
 	sshSession *ssh.Session
 
 	// SSH Client connection is managed externally
-	externClient bool
+	managedSession bool
 }
 
 // Close closes an existing SSH session and socket if they exist.


### PR DESCRIPTION
This enables user to initiate and manage (including closing) of ssh client externally.
This enables transport session to reuse external ssh client for multiple sessions.

closes #124 